### PR TITLE
Added pull approval support

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,10 @@
+approve_by_comment: true
+approve_regex: ^Approved
+reject_regex: ^Rejected
+reset_on_push: false
+reviewers:
+  members:
+  - ckometter
+  - zibrov-zlobin
+  name: pullapprove
+  required: 1


### PR DESCRIPTION
afyservers now uses pull approval. Direct commits to master are not allowed. Contributions can only be made by merging a branch and require an approval from another member.